### PR TITLE
Removing new commit requirement.

### DIFF
--- a/.8451/metadata.yml
+++ b/.8451/metadata.yml
@@ -1,0 +1,14 @@
+program: Science & Developer Services
+profit_stream: enterprise_capabilities
+value_stream: DevSecOps
+product: SDS
+capability: Build
+component: ext-fork-github-tag-action
+team: Dev Pipelines
+contacts:
+  team:
+    - EC-SoftwareDeliverySystem_DL@8451.com
+  technical:
+    - EC-SoftwareDeliverySystem_DL@8451.com
+  product:
+    - EC-SoftwareDeliverySystem_DL@8451.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@master
       with:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 A Github Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.
 
-[![Build Status](https://github.com/anothrNick/github-tag-action/workflows/Bump%20version/badge.svg)](https://github.com/anothrNick/github-tag-action/workflows/Bump%20version/badge.svg)
-[![Stable Version](https://img.shields.io/github/v/tag/anothrNick/github-tag-action)](https://img.shields.io/github/v/tag/anothrNick/github-tag-action)
-[![Latest Release](https://img.shields.io/github/v/release/anothrNick/github-tag-action?color=%233D9970)](https://img.shields.io/github/v/release/anothrNick/github-tag-action?color=%233D9970)
+> **IMPORTANT:** This is a fork of [anothrNick/github-tag-action](https://github.com/anothrNick/github-tag-action), and is branched fo development from tag [1.36.0](https://github.com/anothrNick/github-tag-action/releases/tag/1.36.0) (commit hash [ce4b5ffa38e072fa7a901e417253c438fcc2ccce](https://github.com/anothrNick/github-tag-action/tree/ce4b5ffa38e072fa7a901e417253c438fcc2ccce)).
 
-> Medium Post: [Creating A Github Action to Tag Commits](https://itnext.io/creating-a-github-action-to-tag-commits-2722f1560dec)
-
-[<img src="https://miro.medium.com/max/1200/1*_4Ex1uUhL93a3bHyC-TgPg.png" width="400">](https://itnext.io/creating-a-github-action-to-tag-commits-2722f1560dec)
 
 ### Usage
 
@@ -20,13 +15,13 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.36.0
+      uses: ext-fork-github-tag-action@1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
@@ -53,6 +48,7 @@ _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all
 #### Outputs
 
 - **new_tag** - The value of the newly created tag.
+
 - **tag** - The value of the latest tag after running this action.
 - **part** - The part of version which was bumped.
 
@@ -82,13 +78,3 @@ If `#none` is contained in the commit message, it will skip bumping regardless `
 ### Credits
 
 [fsaintjacques/semver-tool](https://github.com/fsaintjacques/semver-tool)
-
-### Projects using github-tag-action
-
-A list of projects using github-tag-action for reference.
-
-- another/github-tag-action (uses itself to create tags)
-
-- [anothrNick/json-tree-service](https://github.com/anothrNick/json-tree-service)
-
-  > Access JSON structure with HTTP path parameters as keys/indices to the JSON.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,9 +77,9 @@ tag_commit=$(git rev-list -n 1 $tag)
 commit=$(git rev-parse HEAD)
 
 if [ "$tag_commit" == "$commit" ]; then
-    echo "No new commits since previous tag. Skipping..."
-    echo ::set-output name=tag::$tag
-    exit 0
+    echo "No new commits since previous tag."
+    # echo ::set-output name=tag::$tag
+    # exit 0
 fi
 
 # echo log if verbose is wanted

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,9 +77,13 @@ tag_commit=$(git rev-list -n 1 $tag)
 commit=$(git rev-parse HEAD)
 
 if [ "$tag_commit" == "$commit" ]; then
+    #
+    # Inform the user that the commit hash is the same as the tag,
+    # but do not exit.
+    #
+    # This allows users to apply multiple tags to the same commit.
+    #
     echo "No new commits since previous tag."
-    # echo ::set-output name=tag::$tag
-    # exit 0
 fi
 
 # echo log if verbose is wanted
@@ -93,12 +97,20 @@ case "$log" in
     *#minor* ) new=$(semver -i minor $tag); part="minor";;
     *#patch* ) new=$(semver -i patch $tag); part="patch";;
     *#none* ) 
-        echo "Default bump was set to none. Skipping..."; echo ::set-output name=new_tag::$tag; echo ::set-output name=tag::$tag; exit 0;;
+        echo "Default bump was set to none. Skipping..."
+        echo "new_tag=$tag" >> $GITHUB_OUTPUT
+        echo "tag=$tag" >> $GITHUB_OUTPUT
+        exit 0
+        ;;
     * ) 
         if [ "$default_semvar_bump" == "none" ]; then
-            echo "Default bump was set to none. Skipping..."; echo ::set-output name=new_tag::$tag; echo ::set-output name=tag::$tag; exit 0 
+            echo "Default bump was set to none. Skipping..."
+            echo "new_tag=$tag" >> $GITHUB_OUTPUT
+            echo "tag=$tag" >> $GITHUB_OUTPUT
+            exit 0 
         else 
-            new=$(semver -i "${default_semvar_bump}" $tag); part=$default_semvar_bump 
+            new=$(semver -i "${default_semvar_bump}" $tag)
+            part=$default_semvar_bump 
         fi 
         ;;
 esac
@@ -138,17 +150,18 @@ else
 fi
 
 # set outputs
-echo ::set-output name=new_tag::$new
-echo ::set-output name=part::$part
+echo "new_tag=$new" >> $GITHUB_OUTPUT
+echo "part=$part" >> $GITHUB_OUTPUT
 
 # use dry run to determine the next tag
 if $dryrun
 then
-    echo ::set-output name=tag::$tag
+    echo "tag=$tag" >> $GITHUB_OUTPUT
     exit 0
 fi 
 
-echo ::set-output name=tag::$new
+
+echo "tag=$tag" >> $GITHUB_OUTPUT
 
 # create local git tag
 git tag $new

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,15 +153,20 @@ fi
 echo "new_tag=$new" >> $GITHUB_OUTPUT
 echo "part=$part" >> $GITHUB_OUTPUT
 
+if $pre_release
+then
+    echo "tag=$pre_tag" >> $GITHUB_OUTPUT
+else
+    echo "tag=$tag" >> $GITHUB_OUTPUT
+fi
+
+
 # use dry run to determine the next tag
 if $dryrun
 then
-    echo "tag=$tag" >> $GITHUB_OUTPUT
     exit 0
 fi 
 
-
-echo "tag=$tag" >> $GITHUB_OUTPUT
 
 # create local git tag
 git tag $new


### PR DESCRIPTION
### What does this pull request include?

- Comments out the code that required a new commit for adding the tag or bumping the version.

### How does this affect other teams?

- Better supports the common Enterprise ways of working patterns, and enables build to be rerun from the GH UI without false failures do to an unnecessary (read: opinionated) restriction.

### Issues Addressed
- [EFFOEC-16982](https://jira.kroger.com/jira/browse/EFFOEC-16982)

### Successful runs

#### Docker Example

Workflow run: https://github.com/8451LLC/sds-example-docker/actions/runs/5258053556

Setting aside the runner cleanup issue encountered on Attempt 2, the Attempts 1 and 3 on the workflow run above demonstrate:

- (Attempt 1) Triggered on push event: an initial pre-release run with a suffix and a counter 
- (Attempt 3) UI Rerun: a manual re-run from the UI against the same commit which detected the previous version/tag from Attempt 1 and generated a new version/tag as we would expect.

#### Java Lib Example

Workflow Run: https://github.com/8451LLC/sds-example-java-library/actions/runs/5268824224

- (Attempt 1) Ran successfully, created a new tag.
- (Attempt 2) UI Rerun: Failed due to another external bug in other RWs (unrelated, but fixed)
- (Attempt 3) UI Rerun: Succeeded with proper semver and tagging


### Checklist
- [ n/a ] Added automated tests, identified manual testing scenarios
- [x] Added README.md or Confluence documentation where appropriate