### PR TITLE
Update reference to head branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ echo -e "\tTAG_CONTEXT: ${tag_context}"
 echo -e "\tPRERELEASE_SUFFIX: ${suffix}"
 echo -e "\tVERBOSE: ${verbose}"
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
+current_branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"


### PR DESCRIPTION
During PRs, the incorrect head branch was picked up by the action, this change should ensure that it always picks up the correct branch for both PRs and pushes.